### PR TITLE
refactor: change to module implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,5 +21,11 @@
     "not dead",
     "not ie <= 11",
     "not op_mini all"
-  ]
+  ],
+  "devDependencies": {
+    "@types/node": "^10.12.18",
+    "@types/react": "^16.7.18",
+    "@types/react-dom": "^16.0.11",
+    "typescript": "^3.2.2"
+  }
 }

--- a/src/Card/index.tsx
+++ b/src/Card/index.tsx
@@ -4,32 +4,36 @@ interface HocProps {
   foo?: string;
 }
 
-// HOC
-function withHoc<P extends HocProps>(Component: React.ComponentType<P>) {
-  const hocProps = { foo: 'bar' } as HocProps;
-  return (props: any) => <Component {...hocProps} {...props} />
+export interface BaseHocModule {
+  Container: React.FunctionComponent;
+}
+
+export function injectProps(Container: React.FunctionComponent, hocProps: HocProps) {
+  return (props: any) => <Container {...hocProps} {...props} />
+}
+
+export function withHoc<T extends BaseHocModule>(Module: T): T {
+  const hocProps: HocProps = { foo: 'bar' };
+  const {Container, ...rest} = Module;
+
+  return {
+    Container: injectProps(Container, hocProps),
+    ...rest
+  } as T
 };
 
-interface CardSFC<T> extends React.SFC<T> {
-  Title: React.SFC;
-}
-
-interface CardProps extends React.HTMLProps<HTMLDivElement> {
-  Title: React.SFC;
-}
-
-// Parent Component
-const Card: CardSFC<CardProps> = (props) => {
-  const { children, ...rest } = props;
+export type CardContainerInterface = React.FunctionComponent<React.HTMLProps<HTMLDivElement>>;
+export const CardContainerComponent: CardContainerInterface = ({ children, ...props }) => {
   return (
-    <div className="card" {...rest}>
+    <div className="card" {...props}>
       {children}
     </div>
   );
 };
 
-// Child Component
-const Title: React.SFC<React.HTMLProps<HTMLHeadingElement>> = ({ children, ...props }) => {
+export type CardTitleProps = React.HTMLProps<HTMLHeadingElement>
+export type CardTitleInterface = React.FunctionComponent<React.HTMLProps<HTMLHeadingElement>>;
+export const CardTitleComponent: CardTitleInterface = ({ children, ...props }) => {
   return (
     <h1 className="card-title" {...props}>
       {children}
@@ -37,6 +41,13 @@ const Title: React.SFC<React.HTMLProps<HTMLHeadingElement>> = ({ children, ...pr
   );
 };
 
-Card.Title = Title;
+export interface CardModuleInterface {
+  Container: CardContainerInterface;
+  Title: CardTitleInterface;
+};
+export const CardModule: CardModuleInterface = {
+  Container: CardContainerComponent,
+  Title: CardTitleComponent,
+}
 
-export default withHoc<Card>(Card);
+export default withHoc(CardModule);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,9 +6,9 @@ import Card from "./Card";
 const App: React.SFC = () => {
   return (
     <div>
-      <Card>
+      <Card.Container>
         <Card.Title>hello world</Card.Title>
-      </Card>
+      </Card.Container>
     </div>
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -725,6 +725,31 @@
     "@svgr/core" "^2.4.1"
     loader-utils "^1.1.0"
 
+"@types/node@^10.12.18":
+  version "10.12.18"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.18.tgz#1d3ca764718915584fcd9f6344621b7672665c67"
+  integrity sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==
+
+"@types/prop-types@*":
+  version "15.5.8"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.8.tgz#8ae4e0ea205fe95c3901a5a1df7f66495e3a56ce"
+  integrity sha512-3AQoUxQcQtLHsK25wtTWIoIpgYjH3vSDroZOUr7PpCHw/jLY1RB9z9E8dBT/OSmwStVgkRNvdh+ZHNiomRieaw==
+
+"@types/react-dom@^16.0.11":
+  version "16.0.11"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.0.11.tgz#bd10ccb0d9260343f4b9a49d4f7a8330a5c1f081"
+  integrity sha512-x6zUx9/42B5Kl2Vl9HlopV8JF64wLpX3c+Pst9kc1HgzrsH+mkehe/zmHMQTplIrR48H2gpU7ZqurQolYu8XBA==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react@*", "@types/react@^16.7.18":
+  version "16.7.18"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.7.18.tgz#f4ce0d539a893dd61e36cd11ae3a5e54f5a48337"
+  integrity sha512-Tx4uu3ppK53/iHk6VpamMP3f3ahfDLEVt3ZQc8TFm30a1H3v9lMsCntBREswZIW/SKrvJjkb3Hq8UwO6GREBng==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^2.2.0"
+
 "@types/tapable@1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.2.tgz#e13182e1b69871a422d7863e11a4a6f5b814a4bd"
@@ -2306,6 +2331,11 @@ cssstyle@^1.0.0, cssstyle@^1.1.1:
   resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-1.1.1.tgz#18b038a9c44d65f7a8e428a653b9f6fe42faf5fb"
   dependencies:
     cssom "0.3.x"
+
+csstype@^2.2.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.0.tgz#6cf7b2fa7fc32aab3d746802c244d4eda71371a2"
+  integrity sha512-by8hi8BlLbowQq0qtkx54d9aN73R9oUW20HISpka5kmgsR9F7nnxgfsemuR2sdCKZh+CDNf5egW9UZMm4mgJRg==
 
 cyclist@~0.2.2:
   version "0.2.2"
@@ -6695,14 +6725,15 @@ react-dev-utils@^6.1.1:
     strip-ansi "4.0.0"
     text-table "0.2.0"
 
-react-dom@16.6.3:
-  version "16.6.3"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.6.3.tgz#8fa7ba6883c85211b8da2d0efeffc9d3825cccc0"
+react-dom@^16.6.3:
+  version "16.7.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.7.0.tgz#a17b2a7ca89ee7390bc1ed5eb81783c7461748b8"
+  integrity sha512-D0Ufv1ExCAmF38P2Uh1lwpminZFRXEINJe53zRAbm4KPwSyd6DY/uDoS0Blj9jvPpn1+wivKpZYc8aAAN/nAkg==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    scheduler "^0.11.2"
+    scheduler "^0.12.0"
 
 react-error-overlay@^5.1.0:
   version "5.1.0"
@@ -6762,14 +6793,15 @@ react-scripts@2.1.1:
   optionalDependencies:
     fsevents "1.2.4"
 
-react@16.6.3:
-  version "16.6.3"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.6.3.tgz#25d77c91911d6bbdd23db41e70fb094cc1e0871c"
+react@^16.6.3:
+  version "16.7.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.7.0.tgz#b674ec396b0a5715873b350446f7ea0802ab6381"
+  integrity sha512-StCz3QY8lxTb5cl2HJxjwLFOXPIFQp+p+hxQfc8WE0QiLfCtIlKj8/+5tjjKm8uSTlAW+fCPaavGFS06V9Ar3A==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    scheduler "^0.11.2"
+    scheduler "^0.12.0"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"
@@ -7155,9 +7187,10 @@ saxes@^3.1.3:
   dependencies:
     xmlchars "^1.3.1"
 
-scheduler@^0.11.2:
-  version "0.11.2"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.11.2.tgz#a8db5399d06eba5abac51b705b7151d2319d33d3"
+scheduler@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.12.0.tgz#8ab17699939c0aedc5a196a657743c496538647b"
+  integrity sha512-t7MBR28Akcp4Jm+QoR63XgAi9YgCUmgvDHqf5otgAj4QvdoBE4ImCX0ffehefePPG+aitiYHp0g/mW6s4Tp+dw==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
@@ -7882,6 +7915,11 @@ type-is@~1.6.16:
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
+
+typescript@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.2.tgz#fe8101c46aa123f8353523ebdcf5730c2ae493e5"
+  integrity sha512-VCj5UiSyHBjwfYacmDuc/NOk4QQixbE+Wn7MFJuS0nRuPQbof132Pw4u53dm264O8LPc2MVsc7RJNml5szurkg==
 
 uglify-es@^3.3.4:
   version "3.3.9"


### PR DESCRIPTION
@alanbsmith 

First I’ll say that this PR is by no means a complete implementation, but it’s an approximation to your original intention.

The real trouble comes down to a few things:

1. TypeScript is a structural type system - in order for type inference and compatibility, a lens into the structure of the model has to be available
2. “Extending the prototype” as you do with `Card.Title = Title` does not allow for TS to get a proper lens into the structure of the model
3. The signature of withHoc is incompatible with your use of Card in the App
    1. withHoc returns a function, that when instantiated returns a ReactElement
    2. In the render function of the AppComponent, you’re treating it as a FunctionComponent that has been extended to include a Title property, but that’s not what is being returned by withHoc

** I changed the SFC to FunctionComponent in this PR because the @types/react had deprecation warnings on SFC, and that was really just a type alias of FunctionComponent

I ran through a few different scenarios trying to find a pattern that matched yours, this one is somewhat close, but it does adjust the implementation so that you can get proper type inference.

Hope this helps, let’s keep the convo going!